### PR TITLE
Use HashedDescription in location converter and standardize

### DIFF
--- a/src/parachain/mod.rs
+++ b/src/parachain/mod.rs
@@ -112,7 +112,7 @@ impl EnsureOriginWithArg<RuntimeOrigin, Location> for ForeignCreators {
         if !a.starts_with(&origin_location) {
             return Err(o);
         }
-        xcm_config::SovereignAccountOf::convert_location(&origin_location).ok_or(o)
+        xcm_config::LocationToAccountId::convert_location(&origin_location).ok_or(o)
     }
 }
 

--- a/src/parachain/xcm_config/asset_transactor.rs
+++ b/src/parachain/xcm_config/asset_transactor.rs
@@ -2,36 +2,28 @@ pub use sandbox::*;
 
 #[cfg(feature = "start")]
 mod sandbox {
-    pub type SovereignAccountOf = ();
     pub type AssetTransactor = ();
 }
 
 #[cfg(feature = "example")]
 mod sandbox {
-    use polkadot_parachain_primitives::primitives::Sibling;
     use xcm::latest::prelude::*;
     use xcm_builder::{
-        AccountId32Aliases, ConvertedConcreteId, FungibleAdapter, IsConcrete, NoChecking,
-        NonFungiblesAdapter, ParentIsPreset, SiblingParachainConvertsVia,
+        ConvertedConcreteId, FungibleAdapter, IsConcrete, NoChecking,
+        NonFungiblesAdapter,
     };
     use xcm_executor::traits::JustTry;
 
     use crate::parachain::{
-        AccountId, Balances, ForeignUniques, KsmLocation, LocationToAccountId, RelayNetwork,
+        AccountId, Balances, ForeignUniques, KsmLocation, LocationToAccountId,
     };
-
-    pub type SovereignAccountOf = (
-        SiblingParachainConvertsVia<Sibling, AccountId>,
-        AccountId32Aliases<RelayNetwork, AccountId>,
-        ParentIsPreset<AccountId>,
-    );
 
     type LocalAssetTransactor = (
         FungibleAdapter<Balances, IsConcrete<KsmLocation>, LocationToAccountId, AccountId, ()>,
         NonFungiblesAdapter<
             ForeignUniques,
             ConvertedConcreteId<Location, AssetInstance, JustTry, JustTry>,
-            SovereignAccountOf,
+            LocationToAccountId,
             AccountId,
             NoChecking,
             (),

--- a/src/parachain/xcm_config/locations.rs
+++ b/src/parachain/xcm_config/locations.rs
@@ -1,7 +1,6 @@
 use frame_support::parameter_types;
-use polkadot_parachain_primitives::primitives::Sibling;
 use xcm::latest::prelude::*;
-use xcm_builder::{Account32Hash, AccountId32Aliases, ParentIsPreset, SiblingParachainConvertsVia};
+use xcm_builder::{HashedDescription, DescribeFamily, DescribeAllTerminal, AccountId32Aliases};
 
 use crate::parachain::{AccountId, MsgQueue};
 
@@ -12,8 +11,6 @@ parameter_types! {
 }
 
 pub type LocationToAccountId = (
-    ParentIsPreset<AccountId>,
-    SiblingParachainConvertsVia<Sibling, AccountId>,
+    HashedDescription<AccountId, DescribeFamily<DescribeAllTerminal>>,
     AccountId32Aliases<RelayNetwork, AccountId>,
-    Account32Hash<(), AccountId>,
 );

--- a/src/parachain/xcm_config/mod.rs
+++ b/src/parachain/xcm_config/mod.rs
@@ -6,7 +6,6 @@ pub mod origin_converter;
 pub mod reserve;
 pub mod teleporter;
 
-pub use asset_transactor::*;
 pub use limits::*;
 pub use locations::*;
 

--- a/src/relay_chain/xcm_config/locations.rs
+++ b/src/relay_chain/xcm_config/locations.rs
@@ -1,9 +1,8 @@
 use frame_support::parameter_types;
 use xcm::latest::prelude::*;
-use xcm_builder::{Account32Hash, AccountId32Aliases, ChildParachainConvertsVia};
+use xcm_builder::{HashedDescription, DescribeFamily, DescribeAllTerminal, AccountId32Aliases};
 
 use crate::relay_chain::AccountId;
-use polkadot_parachain_primitives::primitives::Id as ParaId;
 
 parameter_types! {
     pub const TokenLocation: Location = Here.into_location();
@@ -13,7 +12,6 @@ parameter_types! {
 }
 
 pub type LocationToAccountId = (
-    ChildParachainConvertsVia<ParaId, AccountId>,
+    HashedDescription<AccountId, DescribeFamily<DescribeAllTerminal>>,
     AccountId32Aliases<RelayNetwork, AccountId>,
-    Account32Hash<(), AccountId>,
 );


### PR DESCRIPTION
I simplified `LocationToAccountId` for both relay and parachain by using only `HashedDescription<AccountId, DescribeFamily<DescribeAllTerminal>>` for remote accounts and `AccountId32Aliases` for local accounts.
This is the standard we want to show in our examples.

Also removed some extra `SovereignAccountOf` types.