### PR TITLE
improve barrier exercise

### DIFF
--- a/parachain/src/configs/xcm/barrier.rs
+++ b/parachain/src/configs/xcm/barrier.rs
@@ -1,25 +1,23 @@
 #![allow(unused_imports)]
 
-use frame_support::traits::Everything;
-use xcm_builder::{AllowTopLevelPaidExecutionFrom, TakeWeightCredit};
-use xcm_executor::traits::ShouldExecute;
+use frame_support::traits::{Everything, ProcessMessageError};
 use xcm::prelude::*;
-use xcm_executor::traits::Properties;
-use frame_support::traits::ProcessMessageError;
+use xcm_builder::{AllowTopLevelPaidExecutionFrom, TakeWeightCredit};
+use xcm_executor::traits::{Properties, ShouldExecute};
 
 pub struct AllowAll;
 impl ShouldExecute for AllowAll {
-    fn should_execute<Call>(
-        _origin: &Location,
-        _instructions: &mut [Instruction<Call>],
-        _max_weight: Weight,
-        _properties: &mut Properties
-    ) -> Result<(), ProcessMessageError> {
-        Ok(())
-    }
+	fn should_execute<Call>(
+		_origin: &Location,
+		_instructions: &mut [Instruction<Call>],
+		_max_weight: Weight,
+		_properties: &mut Properties,
+	) -> Result<(), ProcessMessageError> {
+		Ok(())
+	}
 }
 
 pub type Barrier = (
-    TakeWeightCredit,
-    AllowAll, // TODO replace with correct barrier
+	TakeWeightCredit,
+	AllowAll, // TODO replace with correct barrier
 );

--- a/parachain/src/configs/xcm/barrier.rs
+++ b/parachain/src/configs/xcm/barrier.rs
@@ -2,8 +2,24 @@
 
 use frame_support::traits::Everything;
 use xcm_builder::{AllowTopLevelPaidExecutionFrom, TakeWeightCredit};
+use xcm_executor::traits::ShouldExecute;
+use xcm::prelude::*;
+use xcm_executor::traits::Properties;
+use frame_support::traits::ProcessMessageError;
+
+pub struct AllowAll;
+impl ShouldExecute for AllowAll {
+    fn should_execute<Call>(
+        _origin: &Location,
+        _instructions: &mut [Instruction<Call>],
+        _max_weight: Weight,
+        _properties: &mut Properties
+    ) -> Result<(), ProcessMessageError> {
+        Ok(())
+    }
+}
 
 pub type Barrier = (
     TakeWeightCredit,
-    // TODO: Put the new necessary barrier here. Hint: use the imports :)
+    AllowAll, // TODO replace with correct barrier
 );


### PR DESCRIPTION
The test doesn't fail on `config-1` even though it should (to make the exercise a clear fail-> pass). This PR adds an `AllowAll` barrier to make the test fail.